### PR TITLE
Fix: Bump adapt-authoring-api to ^4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "repository": "github:adapt-security/adapt-authoring-coursetheme",
   "dependencies": {
-    "adapt-authoring-api": "^3.0.0",
+    "adapt-authoring-api": "^4.0.1",
     "lodash": "^4.17.21",
     "semver": "^7.6.0"
   },


### PR DESCRIPTION
Bump adapt-authoring-api to ^4.0.1 so the module builds against the api v4 release (part of the _access rollout). No code changes needed; tests pass and standard is clean.