### PR TITLE
New: Theme schema endpoint + unique preset names per theme (fixes #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,22 @@
 Manages per-course theming for the Adapt authoring tool — the theme settings and customisations applied when a course is built.
 
 Extends `AbstractApiModule` from [adapt-authoring-core](../adapt-authoring-core).
+
+## Theme customiser support
+
+A client (e.g. the UI's theme customiser panel) can fetch a theme's variable schema to render an editor for it:
+
+```
+GET /api/coursethemepresets/theme-schema/:themeName   (scope: read:content)
+```
+
+`:themeName` is the theme plugin's folder name (the config's `_theme`, e.g. `adapt-contrib-vanilla`). The handler reads that theme's `theme.schema.json` straight from the framework source (`<frameworkDir>/src/theme/<themeName>/schema/theme.schema.json`) — theme schemas, unlike core schemas, are not registered with the `jsonschema` module — and returns it verbatim (404 `NO_SCHEMA_DEF` if absent). Values edited against it are saved to the course document's `themeVariables`; an **empty** value is omitted at build time, so the theme's own LESS default applies.
+
+### Optional editor metadata
+
+A theme's `theme.schema.json` may carry extra, build-safe metadata that richer editors read (plain JSON Schema ignores it, so builds and validation are unaffected):
+
+- A top-level `_themeEditor` block: `{ baseTheme, brand: [<leafKey>…], categories: [{ key, title, order }] }` — `brand` is the ordered set of "driver" colours; `categories` are the editor's filter groups.
+
+Preset `displayName` is enforced **unique per `parentTheme`** (case-insensitive, whitespace-trimmed) on create and rename; a clash throws `COURSETHEMEPRESET_NAME_EXISTS` (400). Different themes may reuse the same preset name. This is backed by a compound **unique index** on `{ parentTheme, displayName }` with a case-insensitive collation (`{ locale: 'en', strength: 2 }`) as the DB-level guarantee. (Index creation is guarded: on a DB with pre-existing duplicates it logs a warning instead of failing boot — dedupe, then it builds on next start.)
+- Per-variable `_adapt`: `{ inputType: "ColourPicker", category, row, slot, order, derive?, contrast? }` — `row`+`slot` cluster related variables (e.g. default/inverted) onto one editor row; `derive` (`{ from, transform, amount }`) is a display-only hint for the AUTO value; `contrast` (`{ against, text? }`) declares a known foreground↔background pair for optional WCAG checks.

--- a/errors/errors.json
+++ b/errors/errors.json
@@ -1,0 +1,10 @@
+{
+  "COURSETHEMEPRESET_NAME_EXISTS": {
+    "data": {
+      "displayName": "The preset name",
+      "parentTheme": "The theme the preset belongs to"
+    },
+    "description": "A preset with this name already exists for this theme",
+    "statusCode": 400
+  }
+}

--- a/lib/CourseThemeModule.js
+++ b/lib/CourseThemeModule.js
@@ -20,13 +20,51 @@ class CourseThemeModule extends AbstractApiModule {
   /** @override */
   async init () {
     await super.init()
-    const [framework, content] = await this.app.waitForModule('adaptframework', 'content')
+    const [framework, content, mongodb] = await this.app.waitForModule('adaptframework', 'content', 'mongodb')
     /**
      * Cached module instance for easy access
      * @type {ContentModule}
      */
     this.content = content
     framework.preBuildHook.tap(this.writeCustomLess.bind(this))
+    // Preset names must be unique per theme (case-insensitive). Enforced in three
+    // layers: normalise (trim) on write, a friendly pre-write check for a clean
+    // 400, and a DB-level unique index (the integrity backstop, incl. races).
+    this.preInsertHook.tap(async (data) => {
+      if (typeof data.displayName === 'string') data.displayName = data.displayName.trim()
+      await this.assertUniquePresetName(data.parentTheme, data.displayName)
+    })
+    this.preUpdateHook.tap(async (originalDoc, data) => {
+      if (data.displayName === undefined) return
+      if (typeof data.displayName === 'string') data.displayName = data.displayName.trim()
+      await this.assertUniquePresetName(data.parentTheme ?? originalDoc.parentTheme, data.displayName, originalDoc._id)
+    })
+    // Case-insensitive per-theme unique index. Guarded: a dev DB with pre-existing
+    // duplicates would otherwise fail index creation and block boot (the hooks
+    // still enforce); a clean/production DB builds it and gains the DB guarantee.
+    try {
+      await mongodb.setIndex(this.collectionName, { parentTheme: 1, displayName: 1 }, { unique: true, collation: { locale: 'en', strength: 2 } })
+    } catch (e) {
+      this.log('warn', `could not create unique preset-name index (existing duplicates?): ${e.message}`)
+    }
+  }
+
+  /**
+   * Throws if another preset for the same theme already uses this display name
+   * (case-insensitive). Presets are unique per theme, so the same name may exist
+   * under different `parentTheme` values.
+   * @param {String} parentTheme
+   * @param {String} displayName
+   * @param {String} [excludeId] Ignore this preset (for renames)
+   */
+  async assertUniquePresetName (parentTheme, displayName, excludeId) {
+    const name = (displayName ?? '').trim()
+    if (!name || !parentTheme) return
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const matches = await this.find({ parentTheme, displayName: { $regex: `^${escaped}$`, $options: 'i' } })
+    if (matches.some((p) => String(p._id) !== String(excludeId))) {
+      throw this.app.errors.COURSETHEMEPRESET_NAME_EXISTS.setData({ displayName: name, parentTheme })
+    }
   }
 
   /**
@@ -62,6 +100,30 @@ class CourseThemeModule extends AbstractApiModule {
       await fs.writeFile(`${outputDir}/${filename}`, fileContents)
     } catch (e) {
       this.log('error', `failed to write ${filename}, ${e.message}`)
+    }
+  }
+
+  /**
+   * Serves a theme's `theme.schema.json` (its colour/editor variable schema) so a
+   * client can render a theme customiser. Read straight from the framework source
+   * (`<frameworkDir>/src/theme/<themeName>/schema/theme.schema.json`) because theme
+   * schemas — unlike core schemas — aren't registered with the jsonschema module.
+   * @param {ClientRequest} req
+   * @param {ServerResponse} res
+   * @param {Function} next
+   */
+  async themeSchemaHandler (req, res, next) {
+    try {
+      const { themeName } = req.apiData.query
+      // themeName is a plugin folder name; reject anything that could escape src/theme
+      if (!/^[\w.-]+$/.test(themeName ?? '')) return next(this.app.errors.NO_SCHEMA_DEF)
+      const framework = await this.app.waitForModule('adaptframework')
+      const file = `${framework.path}/src/theme/${themeName}/schema/theme.schema.json`
+      const schema = JSON.parse(await fs.readFile(file, 'utf8'))
+      res.type('application/schema+json').json(schema)
+    } catch (e) {
+      if (e.code === 'ENOENT') return next(this.app.errors.NO_SCHEMA_DEF)
+      return next(e)
     }
   }
 

--- a/routes.json
+++ b/routes.json
@@ -3,6 +3,19 @@
   "permissionsScope": "content",
   "routes": [
     {
+      "route": "/theme-schema/:themeName",
+      "validate": false,
+      "modifying": false,
+      "handlers": { "get": "themeSchemaHandler" },
+      "permissions": { "get": ["read:${scope}"] },
+      "meta": {
+        "get": {
+          "summary": "Retrieve a theme plugin's variable/editor schema",
+          "responses": { "200": {} }
+        }
+      }
+    },
+    {
       "route": "/:_id/apply/:courseId",
       "validate": false,
       "handlers": { "post": "applyHandler" },


### PR DESCRIPTION
### Fixes #62

### New
- GET /api/coursethemepresets/theme-schema/:themeName returns a theme theme.schema.json, read from the framework source (theme schemas are not registered with the jsonschema module). Scope: read:content.

### Update
- Preset displayName is now unique per parentTheme (case-insensitive, trimmed), enforced on create and rename via pre-write hooks plus a Mongo unique index (collation strength 2). Adds the COURSETHEMEPRESET_NAME_EXISTS error.

### Docs
- README documents the endpoint, the optional _themeEditor / _adapt editor metadata a theme schema may carry, and the uniqueness rule.